### PR TITLE
Zed Engine Builder

### DIFF
--- a/docker/zed-engine-builder/Dockerfile
+++ b/docker/zed-engine-builder/Dockerfile
@@ -1,0 +1,13 @@
+# JETSON IMAGE
+# FROM stereolabs/zed:4.0-devel-jetson-jp5.1.1
+# PC IMAGE 
+FROM stereolabs/zed:4.0-devel-cuda12.1-ubuntu22.04
+
+# Install dependencies
+RUN apt update && apt install --yes git cmake make build-essential libnvinfer-dev libnvonnxparsers-dev
+
+WORKDIR /
+RUN git clone https://github.com/RoboEagles4828/zed-engine-builder.git
+
+WORKDIR /zed-engine-builder
+RUN cmake . && make

--- a/docker/zed-engine-builder/Dockerfile
+++ b/docker/zed-engine-builder/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /
 RUN git clone https://github.com/RoboEagles4828/zed-engine-builder.git
 
 WORKDIR /zed-engine-builder
-RUN cmake . && make
+# RUN cmake . && make

--- a/docker/zed-engine-builder/build
+++ b/docker/zed-engine-builder/build
@@ -1,0 +1,24 @@
+#!/bin/bash
+echo "ONLY USE THIS SCRIPT ON THE JETSON"
+
+VERSION=1
+GITHUB_REGISTRY="ghcr.io/roboeagles4828"
+IMAGE_NAME="zed-engine-builder"
+
+docker build -t $GITHUB_REGISTRY/$IMAGE_NAME:$VERSION .
+
+echo "Build finished"
+
+echo "Would you like to run the image in interactive mode? (y/n)"
+read INTERACTIVE
+
+if [ "$INTERACTIVE" = "y" ]; then
+    docker run --rm -it -e ACCEPT_EULA=y $GITHUB_REGISTRY/$IMAGE_NAME:$VERSION
+fi
+
+echo "Would you like to push the image to the registry? (y/n)"
+read PUSH
+
+if [ "$PUSH" = "y" ]; then
+    docker push $GITHUB_REGISTRY/$IMAGE_NAME:$VERSION
+fi


### PR DESCRIPTION
Put our [ZED Engine Builder](https://github.com/RoboEagles4828/zed-engine-builder) into a docker container so that we can build engines for the Jetson without installing tons of dependencies.

(Has not currently been built for or tested on the jetson)